### PR TITLE
fix: is_mobile_data() to support without android

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -73,9 +73,7 @@ impl AfInetInfo {
 
     #[allow(dead_code)]
     pub(crate) fn is_local_network(&self) -> bool {
-        self.iname.contains("eth")
-            || self.iname.contains("wlan")
-            || self.iname.contains("en")
+        self.iname.contains("eth") || self.iname.contains("wlan") || self.iname.contains("en")
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -47,8 +47,35 @@ pub(crate) struct AfInetInfo {
 
 impl AfInetInfo {
     /// Determines if an interface is used for mobile_data
+    /// https://chromium.googlesource.com/external/webrtc/+/branch-heads/m73/rtc_base/network.cc#205
+    #[cfg(target_os = "android")]
     pub(crate) fn is_mobile_data(&self) -> bool {
         self.iname.contains("rmnet_data")
+    }
+
+    #[cfg(target_os = "ios")]
+    pub(crate) fn is_mobile_data(&self) -> bool {
+        self.iname.contains("pdp_ip")
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "windows",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+    ))]
+    pub(crate) fn is_mobile_data(&self) -> bool {
+        false
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_local_network(&self) -> bool {
+        self.iname.contains("eth")
+            || self.iname.contains("wlan")
+            || self.iname.contains("en")
     }
 }
 


### PR DESCRIPTION
local_ip() previously returned mobile IP on iOS platform.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
