### PR TITLE
fix: undo edition and msrv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ keywords = ["local", "ip", "address", "web", "network"]
 license = "MIT OR Apache-2.0"
 version = "0.6.4"
 authors = ["Leo Borai <estebanborai@gmail.com>"]
-edition = "2024"
+edition = "2021"
 readme = "README.md"
-rust-version = "1.86"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Undo MSRV and Edition 2024 on version `0.x`.